### PR TITLE
Adicionar links para os repositórios de Angola e PortugalUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Para evitar que possíveis candidatos enviem cvs para vagas já preenchidas, dê
 - [Vagas para desenvolvedores Stone Pagamentos](https://github.com/stone-pagamentos/vagas)
 - [Vagas para desenvolvedores Vue.js](https://github.com/vuejs-br/vagas)
 - [Vagas para desenvolvedores Go/Golang](https://github.com/Gommunity/vagas)
+- [Vagas para UI/UX](https://github.com/uxbrasil/vagas)
+- [Vagas para desenvolvedores Front-end (Angola)](https://github.com/frontend-ao/vagas)
+- [Vagas para desenvolvedores Back-end (Angola)](https://github.com/backend-ao/vagas)
+- [Vagas para desenvolvedores Front-end (Portugal)](https://github.com/frontend-pt/vagas)
+- [Vagas para desenvolvedores Back-end (Portugal)](https://github.com/backend-pt/vagas)
 
 ## Licença
 


### PR DESCRIPTION
Close #1547 
Adicionar links para os repositórios de vagas para back-end e front-end direcionados aos países Angola e Portugal