### PR TITLE
Vagas antigas

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_ACTIONS }}
+        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 5 dias.'
+        days-before-stale: 60
+        days-before-close: 5


### PR DESCRIPTION
É muito comum ter vagas abertas por muito tempo e que já foram preenchidas mas não fechadas, está action vai fechar qualquer vaga dentro de um período de 35 dias se não houver nenhuma interação na vaga;
um lembrete será feito no 60º dia Se está vaga ainda estiver aberta, faça um comentário, caso ao contrario, a mesma será fechada em 5 dias e uma label será adicionada a issue Falta de informações